### PR TITLE
Use .key instead of deprecated .keyCode, fix #10

### DIFF
--- a/content/stanford-pwdhash.js
+++ b/content/stanford-pwdhash.js
@@ -46,14 +46,14 @@ var SPH_debug = true;
  */
 function SPH_dump(msg) {
   if (SPH_debug) {
-	console.log("pwdhash: " + msg);
+    console.log("pwdhash: " + msg);
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////
 // Constants
 
-const SPH_kPasswordKey = "DOM_VK_F2";
+const SPH_kPasswordKey = "F2";
 const SPH_kPasswordPrefix = "@@";
 const SPH_kMinimumPasswordSize = 5;  // Our defense against focus stealing
 
@@ -80,7 +80,7 @@ SPH_PasswordKeyMonitor.prototype = {
    handleEvent: function(evt) {
 
      // Detect Password Key
-     if (evt.keyCode == evt[SPH_kPasswordKey]) { 
+     if (evt.key == SPH_kPasswordKey) { 
        evt.stopPropagation();   // Don't let user JavaScript see this event
        evt.preventDefault();    // Do not let the character hit the page
        if (evt.type == "keydown") {
@@ -91,11 +91,12 @@ SPH_PasswordKeyMonitor.prototype = {
 
      // Detect Password Prefix
      if (evt.type == "keypress") {
-       var lastChar = String.fromCharCode(evt.charCode);
+       var lastChar = evt.key;
        this.keystream.push(lastChar);
 
-       if (this.keystream.length > SPH_kPasswordPrefix.length)
+       if (this.keystream.length > SPH_kPasswordPrefix.length) {
          this.keystream.shift();
+       }
  
        if (!this.protector && 
            this.keystream.join('') == SPH_kPasswordPrefix) {


### PR DESCRIPTION
Apparently [.keyCode is deprecated](https://stackoverflow.com/a/45771014) and there is also a bug where users can't type the letter q when using the extension. This commit replaces `.keyCode` with the use of `.key`, which should fix the bug and still keep both variants of PwdHash (prefix @@ or password key F2) working. Needs testing.

Successfully tested with Firefox Developer Edition 65.0b6 (64-Bit) on Windows 10 Version 1809 Build 17763.195 (64-Bit).