### PR TITLE
fix key events in FF66

### DIFF
--- a/content/stanford-pwdhash.js
+++ b/content/stanford-pwdhash.js
@@ -81,9 +81,9 @@ SPH_PasswordKeyMonitor.prototype = {
 
      // Detect Password Key
      if (evt.keyCode == evt[SPH_kPasswordKey]) { 
-       evt.stopPropagation();   // Don't let user JavaScript see this event
-       evt.preventDefault();    // Do not let the character hit the page
        if (evt.type == "keydown") {
+         evt.stopPropagation();   // Don't let user JavaScript see this event
+         evt.preventDefault();    // Do not let the character hit the page
          evt.pwdkey = true;
          this.attemptPasswordKeyLogin();
        }
@@ -192,21 +192,21 @@ function SPH_PasswordProtector(field, monitor) {
   this.nextAvail = this.firstAvail;
   this.field = field;
   this.field.setAttribute("secure","yes");
-  window.addEventListener("keydown", this, true);
-  window.addEventListener("keyup", this, true);
-  window.addEventListener("keypress", this, true);
-  window.addEventListener("blur", this, true);
-  window.addEventListener("focus", this, true);
-  window.addEventListener("submit", this, true);
+  field.addEventListener("keydown", this, true);
+  field.addEventListener("keyup", this, true);
+  field.addEventListener("keypress", this, true);
+  field.addEventListener("blur", this, true);
+  field.addEventListener("focus", this, true);
+  field.addEventListener("submit", this, true);
 
   monitor.protector = this;
   this._disable = function() {
-    window.removeEventListener("keydown", this, true);
-    window.removeEventListener("keyup", this, true);
-    window.removeEventListener("keypress", this, true);
-    window.removeEventListener("blur", this, true);
-    window.removeEventListener("focus", this, true);
-    window.removeEventListener("submit", this, true);
+    field.removeEventListener("keydown", this, true);
+    field.removeEventListener("keyup", this, true);
+    field.removeEventListener("keypress", this, true);
+    field.removeEventListener("blur", this, true);
+    field.removeEventListener("focus", this, true);
+    field.removeEventListener("submit", this, true);
     monitor.protector = null;
   }
 }
@@ -252,7 +252,7 @@ SPH_PasswordProtector.prototype = {
     }
 
     // Printable keystrokes should be masked
-    if(evt.type == "keypress" && evt.keyCode == 0) {
+    if(evt.type == "keypress") {
       evt.stopPropagation();   // Don't let user JavaScript see this event
       evt.preventDefault();    // Do not let the character hit the page
       this.addChar(evt.originalTarget, this.mask(evt.charCode));


### PR DESCRIPTION
- fix change in behavior of key events in Firefox 66 (key "q" was disabled in all input fields)
- limit EventListener in SPH_PasswordProtector to password field